### PR TITLE
Fix missing dependency in GameBoard hook

### DIFF
--- a/spudsite-react/src/components/GTVenue.js
+++ b/spudsite-react/src/components/GTVenue.js
@@ -152,6 +152,7 @@ const GameBoard = () => {
       venuesReached,
       setNewVenue,
       setObstacleIntervalDuration,
+      resetGame,
     ]
   );
 


### PR DESCRIPTION
## Summary
- update GTVenue movePlayer hook dependencies

## Testing
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_683fb301d6f0832abf6a0e28c8a1e213