### PR TITLE
Add NavBar test

### DIFF
--- a/spudsite-react/src/components/__tests__/NavBar.test.js
+++ b/spudsite-react/src/components/__tests__/NavBar.test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// Mock the parts of react-router-dom used by NavBar before importing it
+jest.mock('react-router-dom', () => ({
+  MemoryRouter: ({ children }) => <div>{children}</div>,
+  Link: ({ to, children }) => <a href={to}>{children}</a>,
+}), { virtual: true });
+
+import NavBar from '../NavBar';
+import { MemoryRouter } from 'react-router-dom';
+
+test('renders navigation links', () => {
+  render(
+    <MemoryRouter>
+      <NavBar />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByText(/Spuds/i)).toBeInTheDocument();
+  expect(screen.getByText(/Music/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add Jest test for NavBar links using React Testing Library

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_683fbcf9a050832a8b2b6766aef276b0